### PR TITLE
Add lake world, fix initial camera positions

### DIFF
--- a/heron_gazebo/launch/heron_lake_world.launch
+++ b/heron_gazebo/launch/heron_lake_world.launch
@@ -35,10 +35,9 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   <arg name="paused" default="false"/>
   <arg name="set_timeout" default="false"/>
   <arg name="timeout" default="0.0"/>
-
   <!-- We resume the logic in empty_world.launch, changing only the name of the world to be launched -->
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
-      <arg name="world_name" value="$(find heron_gazebo)/worlds/ocean_surface.world"/>
+      <arg name="world_name" value="$(find heron_gazebo)/worlds/lake.world"/>
       <arg name="paused" value="$(arg paused)"/>
       <arg name="use_sim_time" value="true"/>
       <arg name="gui" value="$(arg gui)"/>
@@ -55,29 +54,9 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
       output="screen">
       <rosparam subst_value="true">
           meshes:
-              heightmap:
-                  mesh: package://uuv_gazebo_worlds/models/sand_heightmap/meshes/heightmap.dae
-                  model: sand_heightmap
-              seafloor:
-                  plane: [2000, 2000, 0.1]
-                  pose:
-                      position: [0, 0, -100]
-              north:
-                  plane: [0.1, 2000, 100]
-                  pose:
-                      position: [1000, 0, -50]
-              south:
-                  plane: [0.1, 2000, 100]
-                  pose:
-                      position: [-1000, 0, -50]
-              west:
-                  plane: [2000, 0.1, 100]
-                  pose:
-                      position: [0, -1000, -50]
-              east:
-                  plane: [2000, 0.1, 100]
-                  pose:
-                      position: [0, 1000, -50]
+              lake:
+                  mesh: package://uuv_gazebo_worlds/models/lake/meshes/LakeBottom.dae
+                  model: lake
       </rosparam>
   </node>
 
@@ -86,7 +65,6 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
           <arg name="timeout" value="$(arg timeout)"/>
       </include>
   </group>
-
 
   <!-- Start simulating a Heron -->
   <include file="$(find heron_gazebo)/launch/heron_sim.launch">

--- a/heron_gazebo/launch/heron_lake_world.launch
+++ b/heron_gazebo/launch/heron_lake_world.launch
@@ -35,6 +35,8 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   <arg name="paused" default="false"/>
   <arg name="set_timeout" default="false"/>
   <arg name="timeout" default="0.0"/>
+
+
   <!-- We resume the logic in empty_world.launch, changing only the name of the world to be launched -->
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
       <arg name="world_name" value="$(find heron_gazebo)/worlds/lake.world"/>

--- a/heron_gazebo/launch/heron_world.launch
+++ b/heron_gazebo/launch/heron_world.launch
@@ -24,30 +24,60 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCL
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
 <launch>
-
-  <arg name="world_pkg" default="uuv_gazebo_worlds" />
-  <arg name="world_pkg_file" default="ocean_waves.launch" />
-  <arg name="world_file" default="0" />
-  <arg name="use_pkg_path" default="1" />
-
-  <arg name="hydro_debug" default="0" />
-  <arg name="config" default="base" />
-
   <arg name="x"     default="0"/>
   <arg name="y"     default="0"/>
   <arg name="yaw"   default="0"/>
 
+  <arg name="gui" default="true"/>
+  <arg name="paused" default="false"/>
+  <arg name="set_timeout" default="false"/>
+  <arg name="timeout" default="0.0"/>
+
   <arg name="namespace" default="" />
 
-  <!-- Launch a world file using an absolute file path -->
-  <group unless="$(arg use_pkg_path)">
-    <include file="$(arg world_file)" />
-  </group>
+  <include file="$(find gazebo_ros)/launch/empty_world.launch">
+        <arg name="world_name" value="$(find heron_gazebo)/worlds/ocean_surface.world"/>
+        <arg name="paused" value="$(arg paused)"/>
+        <arg name="use_sim_time" value="true"/>
+        <arg name="gui" value="$(arg gui)"/>
+        <arg name="headless" value="false"/>
+        <arg name="debug" value="false"/>
+        <arg name="verbose" value="true"/>
+    </include>
 
-  <!-- Launch a world file from the launch folder of a package -->
-  <group if="$(arg use_pkg_path)">
-    <include file="$(eval find(arg('world_pkg')) + '/launch/' + arg('world_pkg_file'))" />
-  </group>
+    <include file="$(find uuv_assistants)/launch/publish_world_ned_frame.launch"/>
+
+    <node name="publish_world_models"
+        pkg="uuv_assistants"
+        type="publish_world_models.py"
+        output="screen">
+        <rosparam subst_value="true">
+            meshes:
+                heightmap:
+                    mesh: package://uuv_gazebo_worlds/models/sand_heightmap/meshes/heightmap.dae
+                    model: sand_heightmap
+                seafloor:
+                    plane: [2000, 2000, 0.1]
+                    pose:
+                        position: [0, 0, -100]
+                north:
+                    plane: [0.1, 2000, 100]
+                    pose:
+                        position: [1000, 0, -50]
+                south:
+                    plane: [0.1, 2000, 100]
+                    pose:
+                        position: [-1000, 0, -50]
+                west:
+                    plane: [2000, 0.1, 100]
+                    pose:
+                        position: [0, -1000, -50]
+                east:
+                    plane: [2000, 0.1, 100]
+                    pose:
+                        position: [0, 1000, -50]
+        </rosparam>
+    </node>
 
   <!-- Start simulating a Heron -->
   <include file="$(find heron_gazebo)/launch/heron_sim.launch">

--- a/heron_gazebo/worlds/lake.world
+++ b/heron_gazebo/worlds/lake.world
@@ -1,0 +1,106 @@
+<?xml version="1.0" ?>
+<!-- Copyright (c) 2016 The UUV Simulator Authors.
+     All rights reserved.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<sdf version="1.5">
+  <world name="lake">
+    <physics name="default_physics" default="true" type="ode">
+      <max_step_size>0.002</max_step_size>
+      <real_time_factor>1</real_time_factor>
+      <real_time_update_rate>500</real_time_update_rate>
+      <ode>
+        <solver>
+          <type>quick</type>
+          <iters>50</iters>
+          <sor>0.5</sor>
+        </solver>
+      </ode>
+    </physics>
+    <scene>
+      <ambient>0.01 0.01 0.01 1.0</ambient>
+      <sky>
+        <clouds>
+          <speed>12</speed>
+        </clouds>
+      </sky>
+      <shadows>1</shadows>
+    </scene>
+
+    <!-- Origin placed somewhere in the middle of the Bodensee (Germany)  -->
+    <spherical_coordinates>
+      <latitude_deg>47.6278771</latitude_deg>
+      <longitude_deg>9.334553</longitude_deg>
+    </spherical_coordinates>
+
+      <!-- Global light source -->
+    <light type="directional" name="sun1">
+      <pose>50 0 150 0 0 0</pose>
+      <diffuse>1 1 1 1</diffuse>
+      <specular>.1 .1 .1 1</specular>
+      <direction>0.3 0.3 -1</direction>
+      <cast_shadows>true</cast_shadows>
+    </light>
+
+    <!-- Global light source -->
+    <include>
+      <uri>model://sun</uri>
+    </include>
+
+    <!-- Virtual NED frame -->
+    <include>
+      <uri>model://ned_frame</uri>
+      <pose>0 0 0 0 0 0</pose>
+    </include>
+
+    <!-- Bounding box with sea surface -->
+    <include>
+      <uri>model://lake</uri>
+      <pose>0 0 0 0 0 0</pose>
+    </include>
+
+    <plugin name="underwater_current_plugin" filename="libuuv_underwater_current_ros_plugin.so">
+      <namespace>hydrodynamics</namespace>
+      <constant_current>
+        <topic>current_velocity</topic>
+        <velocity>
+          <mean>0</mean>
+          <min>0</min>
+          <max>5</max>
+          <mu>0.0</mu>
+          <noiseAmp>0.0</noiseAmp>
+        </velocity>
+
+        <horizontal_angle>
+          <mean>0</mean>
+          <min>-3.141592653589793238</min>
+          <max>3.141592653589793238</max>
+          <mu>0.0</mu>
+          <noiseAmp>0.0</noiseAmp>
+        </horizontal_angle>
+
+        <vertical_angle>
+          <mean>0</mean>
+          <min>-3.141592653589793238</min>
+          <max>3.141592653589793238</max>
+          <mu>0.0</mu>
+          <noiseAmp>0.0</noiseAmp>
+        </vertical_angle>
+      </constant_current>
+    </plugin>
+
+    <plugin name="sc_interface" filename="libuuv_sc_ros_interface_plugin.so"/>
+
+  </world>
+</sdf>

--- a/heron_gazebo/worlds/lake.world
+++ b/heron_gazebo/worlds/lake.world
@@ -44,7 +44,7 @@
       <longitude_deg>9.334553</longitude_deg>
     </spherical_coordinates>
 
-      <!-- Global light source -->
+    <!-- Global light source -->
     <light type="directional" name="sun1">
       <pose>50 0 150 0 0 0</pose>
       <diffuse>1 1 1 1</diffuse>
@@ -52,11 +52,13 @@
       <direction>0.3 0.3 -1</direction>
       <cast_shadows>true</cast_shadows>
     </light>
-
-    <!-- Global light source -->
-    <include>
-      <uri>model://sun</uri>
-    </include>
+    <light type="directional" name="sun_diffuse">
+      <pose>-50 0 -150 0 0 0</pose>
+      <diffuse>0.6 0.6 0.6 1</diffuse>
+      <specular>0 0 0 1</specular>
+      <direction>-0.3 -0.3 -1</direction>
+      <cast_shadows>true</cast_shadows>
+    </light>
 
     <!-- Virtual NED frame -->
     <include>
@@ -101,6 +103,14 @@
     </plugin>
 
     <plugin name="sc_interface" filename="libuuv_sc_ros_interface_plugin.so"/>
+
+    <gui fullscreen='0'>
+      <camera name='user_camera'>
+        <pose frame=''>7.312378 -1.516460 1.276953 0.0  0.084001 2.896383</pose>
+        <view_controller>orbit</view_controller>
+        <projection_type>perspective</projection_type>
+      </camera>
+    </gui>
 
   </world>
 </sdf>

--- a/heron_gazebo/worlds/ocean_surface.world
+++ b/heron_gazebo/worlds/ocean_surface.world
@@ -1,0 +1,118 @@
+<?xml version="1.0" ?>
+<!--
+     Copyright (c) 2020 Clearpath Robotics
+
+     Based on UUV Worlds ocean_waves world, details below:
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<sdf version="1.4">
+  <world name="ocean_surface">
+    <physics name="default_physics" default="true" type="ode">
+      <max_step_size>0.002</max_step_size>
+      <real_time_factor>1</real_time_factor>
+      <real_time_update_rate>500</real_time_update_rate>
+    </physics>
+    <scene>
+      <ambient>0.01 0.01 0.01 1.0</ambient>
+      <sky>
+        <clouds>
+          <speed>12</speed>
+        </clouds>
+      </sky>
+      <shadows>1</shadows>
+    </scene>
+
+    <!-- Origin placed somewhere in the middle of the North Sea  -->
+    <spherical_coordinates>
+      <latitude_deg>56.71897669633431</latitude_deg>
+      <longitude_deg>3.515625</longitude_deg>
+    </spherical_coordinates>
+
+    <!-- Global light source -->
+    <light type="directional" name="sun1">
+      <pose>50 0 150 0 0 0</pose>
+      <diffuse>1 1 1 1</diffuse>
+      <specular>.1 .1 .1 1</specular>
+      <direction>0.3 0.3 -1</direction>
+      <cast_shadows>false</cast_shadows>
+    </light>
+
+    <!-- Global light source -->
+    <light type="directional" name="sun_diffuse">
+      <pose>-50 0 -150 0 0 0</pose>
+      <diffuse>0.6 0.6 0.6 1</diffuse>
+      <specular>0 0 0 1</specular>
+      <direction>-0.3 -0.3 -1</direction>
+      <cast_shadows>false</cast_shadows>
+    </light>
+
+    <!-- Virtual NED frame -->
+    <include>
+      <uri>model://ned_frame</uri>
+      <pose>0 0 0 0 0 0</pose>
+    </include>
+
+    <!-- Bounding box with sea surface -->
+    <include>
+      <uri>model://ocean</uri>
+      <pose>0 0 0 0 0 0</pose>
+    </include>
+
+    <!-- Heightmap -->
+    <include>
+      <uri>model://sand_heightmap</uri>
+      <pose>0 0 -95 0 0 0</pose>
+    </include>
+
+    <plugin name="underwater_current_plugin" filename="libuuv_underwater_current_ros_plugin.so">
+      <namespace>hydrodynamics</namespace>
+      <constant_current>
+        <topic>current_velocity</topic>
+        <velocity>
+          <mean>0</mean>
+          <min>0</min>
+          <max>5</max>
+          <mu>0.0</mu>
+          <noiseAmp>0.0</noiseAmp>
+        </velocity>
+
+        <horizontal_angle>
+          <mean>0</mean>
+          <min>-3.141592653589793238</min>
+          <max>3.141592653589793238</max>
+          <mu>0.0</mu>
+          <noiseAmp>0.0</noiseAmp>
+        </horizontal_angle>
+
+        <vertical_angle>
+          <mean>0</mean>
+          <min>-3.141592653589793238</min>
+          <max>3.141592653589793238</max>
+          <mu>0.0</mu>
+          <noiseAmp>0.0</noiseAmp>
+        </vertical_angle>
+      </constant_current>
+    </plugin>
+
+    <plugin name="sc_interface" filename="libuuv_sc_ros_interface_plugin.so"/>
+
+    <gui fullscreen='0'>
+      <camera name='user_camera'>
+        <pose frame=''>-2.648091 -12.955096 5.680429 0.00 0.404000 1.296385</pose>
+        <view_controller>orbit</view_controller>
+        <projection_type>perspective</projection_type>
+      </camera>
+    </gui>
+  </world>
+</sdf>


### PR DESCRIPTION
The ocean world is designed for underwater vehicles, so the initial view is underwater.  Add a copy of the UUV ocean world locally with modified initial camera position so the Heron is actually in-frame.

Because the ocean world is pretty featureless, also add a new lake_world (also based on UUV environment).  The lake world is objectively uglier and has some bad moire patterns on the surface, but it has a couple of small island and more shallow bottom topography.