### PR TITLE
Fix namespace preventing the EKF node from working

### DIFF
--- a/heron_gazebo/launch/spawn_heron.launch
+++ b/heron_gazebo/launch/spawn_heron.launch
@@ -48,20 +48,20 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
     </node>
 
     <!-- Filter for Imu message -->
-    <!--
-      The filter needs MagneticField messages, so start a node to translate from the Vector3Stamped messages
-      provided by the plugin
-    -->
-    <node pkg="heron_gazebo" type="vector3_to_magnetic_field" name="mag_translation">
-      <param name="mag_in"    value="/imu/mag_raw" />
-      <param name="mag_out"   value="/imu/mag" />
-    </node>
     <node pkg="imu_filter_madgwick" type="imu_filter_node" name="imu_filter_madgwick">
       <param name="~use_magnetic_field_msg" value="true" />
       <param name="~use_mag" value="true" />
       <param name="world_frame" value="enu" />
       <param name="publish_debug_topics" value="true" />
       <param name="~publish_tf" value="false" />
+    </node>
+    <!--
+      The filter needs MagneticField messages, so start a node to translate from the Vector3Stamped messages
+      provided by the plugin
+    -->
+    <node pkg="heron_gazebo" type="vector3_to_magnetic_field" name="mag_translation">
+      <remap from="mag_in"    to="imu/mag_raw" />
+      <remap from="mag_out"   to="imu/mag" />
     </node>
 
     <!-- Heron thruster controller -->

--- a/heron_gazebo/scripts/vector3_to_magnetic_field
+++ b/heron_gazebo/scripts/vector3_to_magnetic_field
@@ -17,7 +17,7 @@ def on_mag_recv(data, node):
     node.on_mag_data(data)
 
 class Vector3Stamped_to_MagneticField_node:
-    def __init__(self, node, mag_in='/imu/mag_raw', mag_out='/imu/mag'):
+    def __init__(self, node, mag_in='mag_in', mag_out='mag_out'):
         self.node = node
         self.mag_out = rospy.Publisher(mag_out, MagneticField, queue_size=10)
         self.mag_in = rospy.Subscriber(mag_in, Vector3Stamped, on_mag_recv, self)
@@ -34,11 +34,7 @@ class Vector3Stamped_to_MagneticField_node:
 def vector3_to_magneticField():
     node = rospy.init_node('vector3_to_magneticField', anonymous=True)
 
-    # get the parameters
-    mag_in= rospy.get_param('~mag_in')
-    mag_out = rospy.get_param('~mag_out')
-
-    controller = Vector3Stamped_to_MagneticField_node(node, mag_in, mag_out)
+    controller = Vector3Stamped_to_MagneticField_node(node, 'mag_in', 'mag_out')
 
     rospy.spin()
 


### PR DESCRIPTION
Use remap instead of rosparams to set the topics for the mag topic translator. This allows the node to work correctly when the namespace argument is set.

This should resolve https://github.com/heron/heron_simulator/issues/9