### PR TITLE
Enable thruster joints in simulation

### DIFF
--- a/heron_gazebo/launch/spawn_heron.launch
+++ b/heron_gazebo/launch/spawn_heron.launch
@@ -114,6 +114,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   <include file="$(find heron_description)/launch/description.launch">
     <arg name="namespace" value="$(arg namespace)" />
     <arg name="hydro_debug" value="$(arg hydro_debug)" />
+    <arg name="simulation" value="true" />
   </include>
 
 </launch>


### PR DESCRIPTION
Enable the simulation argument so the thrusters are mobile & allow the robot to move.  This is related to the thruster-fix branch in the heron_description package.