### PR TITLE
Pass the config arg to the heron_description package correctly

### DIFF
--- a/heron_gazebo/launch/spawn_heron.launch
+++ b/heron_gazebo/launch/spawn_heron.launch
@@ -112,9 +112,10 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 
   <!-- Launches Heron's description nodes -->
   <include file="$(find heron_description)/launch/description.launch">
-    <arg name="namespace" value="$(arg namespace)" />
+    <arg name="namespace"   value="$(arg namespace)" />
     <arg name="hydro_debug" value="$(arg hydro_debug)" />
-    <arg name="simulation" value="true" />
+    <arg name="simulation"  value="true" />
+    <arg name="config"      value="$(arg config)" />
   </include>
 
 </launch>


### PR DESCRIPTION
The config arg is currently unused, which appears to be a mistake.
Since Heron only supports the `base` config right now, that's probably why it was never noticed before.