### PR TITLE
change conditional to be py2/3 compat

### DIFF
--- a/heron_gazebo/scripts/cmd_drive_translate
+++ b/heron_gazebo/scripts/cmd_drive_translate
@@ -45,7 +45,7 @@ def translate():
 
     namespace = rospy.get_param("~namespace", "")
 
-    if namespace is "":
+    if namespace == "":
         namespace = "heron"
 
     p_left = rospy.Publisher("/" + namespace + "/thrusters/1/input", FloatStamped, queue_size=1)


### PR DESCRIPTION
```bash
/home/acxz/vcs/git/github/acxz/heron_ws/src/heron_simulator/heron_gazebo/scripts/cmd_drive_translate:48: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if namespace is "":
```